### PR TITLE
Fixed cpu usage at 101%

### DIFF
--- a/uc_tronics_display/lcd_display/rpiInfo.c
+++ b/uc_tronics_display/lcd_display/rpiInfo.c
@@ -174,11 +174,11 @@ uint8_t get_cpu_message(void)
     int usCpu = 0;
     int syCpu = 0;
 
-    fp=popen("top -bn1 | grep %Cpu | awk '{printf \"%.2f\", $(2)}'","r");    //Gets the load on the CPU
+    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%.2f\", $(2)}'","r");    //Gets the load on the CPU
     fgets(usCpuBuff, sizeof(usCpuBuff),fp);                                    //Read the user CPU load
     pclose(fp);    
 
-    fp=popen("top -bn1 | grep %Cpu | awk '{printf \"%.2f\", $(4)}'","r");    //Gets the load on the CPU
+    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%.2f\", $(4)}'","r");    //Gets the load on the CPU
     fgets(syCpubuff, sizeof(syCpubuff),fp);                                    //Read the system CPU load
     pclose(fp);   
     usCpu = atoi(usCpuBuff);

--- a/uc_tronics_display/lcd_display/rpiInfo.c
+++ b/uc_tronics_display/lcd_display/rpiInfo.c
@@ -174,11 +174,11 @@ uint8_t get_cpu_message(void)
     int usCpu = 0;
     int syCpu = 0;
 
-    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%.2f\", $(2)}'","r");    //Gets the load on the CPU
+    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%d\", $(2)}'","r");    //Gets the load on the CPU
     fgets(usCpuBuff, sizeof(usCpuBuff),fp);                                    //Read the user CPU load
     pclose(fp);    
 
-    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%.2f\", $(4)}'","r");    //Gets the load on the CPU
+    fp=popen("top -bn1 | grep -m 1 -e CPU | awk '{printf \"%d\", $(4)}'","r");    //Gets the load on the CPU
     fgets(syCpubuff, sizeof(syCpubuff),fp);                                    //Read the system CPU load
     pclose(fp);   
     usCpu = atoi(usCpuBuff);


### PR DESCRIPTION
Changes in `get_cpu_message()`

- changed grep target to 'CPU'
- added filter for grep
- removed float conversion of usage value

Hass.io uses different row name for cpu usage, additionally uses percentage instead of fraction.
From Home Assistant:

```bash
$ top
Mem: 1786076K used, 2096116K free, 1440K shrd, 103224K buff, 953800K cached
CPU:   0% usr   0% sys   0% nic  98% idle   0% io   0% irq   0% sirq
Load average: 0.84 1.23 1.17 2/570 299
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
  193   157 root     S     6632   0%   2   0% sshd: root@pts/0
```

Ubuntu example:

```bash
$ top
top - 00:32:20 up 3 days, 55 min,  6 users,  load average: 0.53, 0.38, 0.36
Tasks: 393 total,   1 running, 391 sleeping,   0 stopped,   1 zombie
%Cpu(s):  0.5 us,  1.5 sy,  1.0 ni, 97.1 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  39023.1 total,  26581.8 free,   7949.3 used,   4492.1 buff/cache
MiB Swap:  16384.0 total,  16384.0 free,      0.0 used.  28497.3 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
   1057 root      32  12 1876104  46452  32000 S   6.2   0.1   1:23.63 containerd
```

Testet on Raspberry pi 4B with Home Assistant:

- Core 2023.4.3
- Supervisor 2024.04.0
- Operating System 12.2

